### PR TITLE
Added Roller Shutter (ISR2) - shutterLevel support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ As this project is developed during my spare time, I*m actively looking for help
 
 ## Changelog
 
+### 0.3.4
+    Added Roller Shutter (ISR2) - shutterLevel support
+
 ### 0.3.3
     Fixed non switchable variables for new installations (missing native ID)
 

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
     "common": {
         "name": "innogy-smarthome",
-        "version": "0.3.3",
+        "version": "0.3.4",
         "title": "Innogy Smarthome Adapter",
         "license": "MIT",
         "desc": {

--- a/main.js
+++ b/main.js
@@ -618,6 +618,14 @@ function getCommonForState(aState) {
             res.write = true;
             break;
 
+        // -- ROLLER SHUTTER --
+        case "shutterLevel":
+            res.type = "number";
+            res.role = "level";
+            res.read = true;
+            res.write = true;
+            break;
+
 
         default:
             adapter.log.warn('Unknown state (please report to dev):' + aState.name + " " + JSON.stringify(aState));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iobroker.innogy-smarthome",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "ioBroker Innogy SmartHome Adapter",
   "author": {
     "name": "Patrick Arns",


### PR DESCRIPTION
Added support for my Innogy ISR2 roller shutter. **shutterLevel** property was unknown. Successfully tested it at my innogy installation.